### PR TITLE
Prevent cached double counting and dupes

### DIFF
--- a/lib/acts_as_favoritor/favoritor.rb
+++ b/lib/acts_as_favoritor/favoritor.rb
@@ -50,10 +50,10 @@ module ActsAsFavoritor
         self.class.build_result_for_scopes(scopes || scope) do |s|
           return nil if self == favoritable
 
-          favorites.for_favoritable(favoritable).send("#{s}_list")
-                   .first_or_create!
-
+          result = favorites.for_favoritable(favoritable).send("#{s}_list")
+                            .first_or_create!
           inc_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
+          result
         end
       end
 
@@ -64,9 +64,9 @@ module ActsAsFavoritor
           favorite_record = get_favorite(favoritable, s)
           return nil unless favorite_record.present?
 
-          favorite_record.destroy!
-
+          result = favorite_record.destroy!
           dec_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
+          result
         end
       end
 

--- a/lib/acts_as_favoritor/favoritor.rb
+++ b/lib/acts_as_favoritor/favoritor.rb
@@ -50,10 +50,10 @@ module ActsAsFavoritor
         self.class.build_result_for_scopes(scopes || scope) do |s|
           return nil if self == favoritable
 
-          inc_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
-
           favorites.for_favoritable(favoritable).send("#{s}_list")
                    .first_or_create!
+
+          inc_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
         end
       end
 
@@ -64,8 +64,9 @@ module ActsAsFavoritor
           favorite_record = get_favorite(favoritable, s)
           return nil unless favorite_record.present?
 
-          dec_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
           favorite_record.destroy!
+
+          dec_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
         end
       end
 

--- a/lib/generators/templates/migration.rb.erb
+++ b/lib/generators/templates/migration.rb.erb
@@ -18,6 +18,9 @@ class ActsAsFavoritorMigration < ActiveRecord::Migration<%= migration_version %>
     add_index :favorites,
               ['favoritable_id', 'favoritable_type'],
               name: 'fk_favoritables'
+    add_index :favorites,
+              ['favoritable_id', 'favoritor_id', 'favoritable_type'],
+              name: 'uniq_favorites__and_favoritables', unique: true
   end
 
   def self.down


### PR DESCRIPTION
The Gem allows for duplicate favorites for a single favoritor if favorite'ing is done rapidly. This is because there is no unique constraint on the DB and the caching is done before any unique constraints might fail a duplicate (if they were to exist).

This PR adds the constraints to the DB index and re-orders caching to only count AFTER the db inserts/destroys are successful so caching is more likely to reflect reality.