### PR TITLE
Fix bugs in dedup logic

### DIFF
--- a/lib/acts_as_favoritor/favoritor.rb
+++ b/lib/acts_as_favoritor/favoritor.rb
@@ -50,10 +50,11 @@ module ActsAsFavoritor
         self.class.build_result_for_scopes(scopes || scope) do |s|
           return nil if self == favoritable
 
-          result = favorites.for_favoritable(favoritable).send("#{s}_list")
-                            .first_or_create!
-          inc_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
-          result
+          favorites.for_favoritable(favoritable).send("#{s}_list")
+                   .first_or_create! do |new_record|
+            inc_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
+            new_record
+          end
         end
       end
 
@@ -65,7 +66,7 @@ module ActsAsFavoritor
           return nil unless favorite_record.present?
 
           result = favorite_record.destroy!
-          dec_cache(favoritable, s) if ActsAsFavoritor.configuration.cache
+          dec_cache(favoritable, s) if ActsAsFavoritor.configuration.cache && result.destroyed?
           result
         end
       end

--- a/lib/generators/templates/migration.rb.erb
+++ b/lib/generators/templates/migration.rb.erb
@@ -19,7 +19,8 @@ class ActsAsFavoritorMigration < ActiveRecord::Migration<%= migration_version %>
               ['favoritable_id', 'favoritable_type'],
               name: 'fk_favoritables'
     add_index :favorites,
-              ['favoritable_id', 'favoritor_id', 'favoritable_type'],
+              ['favoritable_type', 'favoritable_id', 'favoritor_type',
+              'favoritor_id', 'scope'],
               name: 'uniq_favorites__and_favoritables', unique: true
   end
 


### PR DESCRIPTION
I noticed two bugs in my previous PR (#229).

1. The unique constraint was incorrect.
2. Relying on unique constraint exceptions and destroy was incorrect.

For (1), I forgot to include some scopes and types. Favorites should be unique by favoritor/favoritable + favoritor type/favoritable type + scope. I've corrected this.

For (2), it turns out that `first_or_create!` does not raise an exception if a row already exists; it does, however, [take a `do` block that is only run when a new record is created](https://stackoverflow.com/questions/14510813/first-or-create-determining-which-is-called). We now only increment that cache in the `do` block.

Sorry I didn't catch these earlier. My use case didn't detect (1), and my manual verification did not detect (2) yesterday. I've run it through several rounds of verification now and everything seems OK.