### PR TITLE
Fixed rails 7.2 deprecation warning

### DIFF
--- a/lib/acts_as_favoritor/favoritable.rb
+++ b/lib/acts_as_favoritor/favoritable.rb
@@ -9,8 +9,8 @@ module ActsAsFavoritor
     module ClassMethods
       def acts_as_favoritable
         if ActsAsFavoritor.configuration&.cache
-          serialize :favoritable_score, Hash
-          serialize :favoritable_total, Hash
+          serialize :favoritable_score, type: Hash
+          serialize :favoritable_total, type: Hash
         end
 
         has_many :favorited, as: :favoritable, dependent: :destroy,

--- a/lib/acts_as_favoritor/favoritor.rb
+++ b/lib/acts_as_favoritor/favoritor.rb
@@ -9,8 +9,8 @@ module ActsAsFavoritor
     module ClassMethods
       def acts_as_favoritor
         if ActsAsFavoritor.configuration&.cache
-          serialize :favoritor_score, Hash
-          serialize :favoritor_total, Hash
+          serialize :favoritor_score, type: Hash
+          serialize :favoritor_total, type: Hash
         end
 
         has_many :favorites, as: :favoritor, dependent: :destroy


### PR DESCRIPTION
related to #491 

fixed the deprecation warning thrown by Rails 7.1, as you now need to pass the class as a keyword argument in serializer.