### PR TITLE
Fix undefined_method timestamped_migrations error

### DIFF
--- a/lib/generators/acts_as_favoritor_generator.rb
+++ b/lib/generators/acts_as_favoritor_generator.rb
@@ -10,10 +10,10 @@ class ActsAsFavoritorGenerator < Rails::Generators::Base
   desc 'Install acts_as_favoritor'
 
   def self.timestamped_migrations
-    if ActiveRecord::Base.respond_to?(:timestamped_migrations)
-      ActiveRecord::Base.timestamped_migrations
-    elsif ActiveRecord.respond_to?(:timestamped_migrations)
+    if ActiveRecord.respond_to?(:timestamped_migrations)
       ActiveRecord.timestamped_migrations
+    elsif ActiveRecord::Base.respond_to?(:timestamped_migrations)
+      ActiveRecord::Base.timestamped_migrations
     end
   end
 


### PR DESCRIPTION
The following error occurred when running `rails g acts_as_favoriter` using Rails 7.1.3.4, so I fixed it.

`.../active_record/dynamic_matchers.rb:22:in method_missing': undefined method timestamped_migrations' for class ActiveRecord::Base (NoMethodError)`

ActiveRecord.timestamped_migrations is now used when the major version of rails is 7 or higher, and making that the first in the conditional gets past the error.
